### PR TITLE
Expose CloudHSM in Sandbox Environment to GDS IP Range

### DIFF
--- a/clusters/sandbox-values.yaml
+++ b/clusters/sandbox-values.yaml
@@ -1,1 +1,2 @@
 ---
+cloudHSMExpose: true


### PR DESCRIPTION
This exposes the sandbox cloudhsm for use by EIDAS in their local development environment.

Solo: @smford