### PR TITLE
Change service operator test namespaces

### DIFF
--- a/clusters/sandbox-values.yaml
+++ b/clusters/sandbox-values.yaml
@@ -36,8 +36,4 @@ namespaces:
   path: ci/sandbox
   requiredApprovalCount: 0
 - name: spike-dcs-mtls
-- name: sandbox-aws-service-operator-test
-  roles:
-  - name: app-1
-    policies:
-    - sqs
+- name: sandbox-gsp-service-operator-test


### PR DESCRIPTION
Remove the old AWS one and its namespace role stuff
(going away in https://github.com/alphagov/gsp/pull/412),
add a new one for GSP.