### PR TITLE
Safelist SQS legacy endpoint too

### DIFF
--- a/clusters/sandbox-values.yaml
+++ b/clusters/sandbox-values.yaml
@@ -7,6 +7,8 @@ global:
 httpsEgressSafelist:
 - name: sqs-eu-west-2
   fqdn: sqs.eu-west-2.amazonaws.com
+- name: queue-eu-west-2
+  fqdn: eu-west-2.queue.amazonaws.com # legacy endpoint
 - name: stub-connector
   fqdn: test-connector.london.sandbox.govsvc.uk
 - name: test-intgegration


### PR DESCRIPTION
awscli uses this because boto3 does.