### PR TITLE
Allow clusters access to RDS via `egressSafelist` specifying host and port

### DIFF
--- a/clusters/sandbox-values.yaml
+++ b/clusters/sandbox-values.yaml
@@ -4,11 +4,21 @@ global:
     enabled: true
     ip: "10.101.29.134"
 
-httpsEgressSafelist:
+egressSafelist:
 - name: sqs-eu-west-2
   fqdn: sqs.eu-west-2.amazonaws.com
 - name: queue-eu-west-2
   fqdn: eu-west-2.queue.amazonaws.com # legacy endpoint
+
+- name: rds
+  hosts: ["*.rds.amazonaws.com"]
+  ports:
+  - name: postgres
+    number: 5432
+    protocol: TCP
+  location: MESH_EXTERNAL
+  resolution: DNS
+
 - name: stub-connector
   fqdn: test-connector.london.sandbox.govsvc.uk
 - name: test-intgegration

--- a/clusters/sandbox-values.yaml
+++ b/clusters/sandbox-values.yaml
@@ -5,10 +5,16 @@ global:
     ip: "10.101.29.134"
 
 egressSafelist:
-- name: sqs-eu-west-2
-  fqdn: sqs.eu-west-2.amazonaws.com
-- name: queue-eu-west-2
-  fqdn: eu-west-2.queue.amazonaws.com # legacy endpoint
+- name: sqs
+  hosts:
+    - "sqs.eu-west-2.amazonaws.com"
+    - "eu-west-2.queue.amazonaws.com"
+  ports:
+  - name: https
+    number: 443
+    protocol: TLS
+  location: MESH_EXTERNAL
+  resolution: DNS
 
 - name: rds
   hosts: ["*.rds.amazonaws.com"]
@@ -19,12 +25,32 @@ egressSafelist:
   location: MESH_EXTERNAL
   resolution: DNS
 
-- name: stub-connector
-  fqdn: test-connector.london.sandbox.govsvc.uk
-- name: test-intgegration
-  fqdn: test-integration-connector.london.sandbox.govsvc.uk
-- name: hub-integration
-  fqdn: www.integration.signin.service.gov.uk
+- name: verify-connector-sandbox
+  hosts: ["test-connector.london.sandbox.govsvc.uk"]
+  ports:
+  - name: https
+    number: 443
+    protocol: TCP
+  location: MESH_EXTERNAL
+  resolution: DNS
+
+- name: verify-integration-connector-sandbox
+  hosts: ["test-integration-connector.london.sandbox.govsvc.uk"]
+  ports:
+  - name: https
+    number: 443
+    protocol: TCP
+  location: MESH_EXTERNAL
+  resolution: DNS
+
+- name: verify-hub-integration
+  hosts: ["www.integration.signin.service.gov.uk"]
+  ports:
+  - name: https
+    number: 443
+    protocol: TCP
+  location: MESH_EXTERNAL
+  resolution: DNS
 
 namespaces:
 - name: sandbox-connector-node-metadata

--- a/clusters/sandbox-values.yaml
+++ b/clusters/sandbox-values.yaml
@@ -17,7 +17,7 @@ egressSafelist:
   resolution: DNS
 
 - name: rds
-  hosts: ["*.rds.amazonaws.com"]
+  hosts: ["*.eu-west-2.rds.amazonaws.com"]
   ports:
   - name: postgres
     number: 5432

--- a/clusters/sandbox-values.yaml
+++ b/clusters/sandbox-values.yaml
@@ -30,7 +30,7 @@ egressSafelist:
   ports:
   - name: https
     number: 443
-    protocol: TCP
+    protocol: TLS
   location: MESH_EXTERNAL
   resolution: DNS
 
@@ -39,7 +39,7 @@ egressSafelist:
   ports:
   - name: https
     number: 443
-    protocol: TCP
+    protocol: TLS
   location: MESH_EXTERNAL
   resolution: DNS
 
@@ -48,7 +48,7 @@ egressSafelist:
   ports:
   - name: https
     number: 443
-    protocol: TCP
+    protocol: TLS
   location: MESH_EXTERNAL
   resolution: DNS
 


### PR DESCRIPTION
- We're using our self-built GSP Service Operator to allow tenants to make use of Amazon RDS instances (Aurora Postgres). Without this change, things in the cluster can't actually access things on rds.amazonaws.com and create, read, update or delete their databases.
- This is in the new syntax based on the edited Helm chart in the GSP repo, because RDS uses different ports to HTTPS and so we're setting values for all of the hosts and ports items now.
- Also we convert the existing ServiceEntry values to the new format so that they apply (this is tested with `hack/lint-teraform-values-output.sh` in the GSP repo. This is more verbose, but users don't have to go digging into the Helm chart templates in the GSP repo to find what values they need to pass, or values that are already there by default, if we specify all of the `spec` block from the template as `details` in this values.yaml.

Relies on https://github.com/alphagov/gsp/pull/426 being merged first so this generates and applies cleanly.

Co-authored-by: Issy Long <isabell.long@digital.cabinet-office.gov.uk>
Co-authored-by: Chris Farmiloe <chris.farmiloe@digital.cabinet-office.gov.uk>

https://trello.com/c/uEbwPqoN/111-make-gsp-service-operator-postgres-support-work