### PR TITLE
changes rds ServiceEntry to TLS proto

### DIFF
--- a/clusters/sandbox-values.yaml
+++ b/clusters/sandbox-values.yaml
@@ -21,7 +21,7 @@ egressSafelist:
   ports:
   - name: postgres
     number: 5432
-    protocol: TCP
+    protocol: TLS
   location: MESH_EXTERNAL
   resolution: DNS
 


### PR DESCRIPTION
it's not possible to use a host with a TCP proto ServiceEntry without a
network endpoint.

postgres is over a TLS connection so it should be TLS.