### PR TITLE
use resolution:NONE for postgres ServiceEntry

### DIFF
--- a/clusters/sandbox-values.yaml
+++ b/clusters/sandbox-values.yaml
@@ -19,12 +19,13 @@ egressSafelist:
 - name: rds
   service:
     hosts: ["*.eu-west-2.rds.amazonaws.com"]
+    addresses: ["10.0.0.0/8"]
     ports:
     - name: postgres
       number: 5432
       protocol: TLS
     location: MESH_EXTERNAL
-    resolution: DNS
+    resolution: NONE
 - name: verify-connector-sandbox
   service:
     hosts: ["test-connector.london.sandbox.govsvc.uk"]


### PR DESCRIPTION
it's not possible to use a wildcard host with DNS resolution.

using resolution:NONE means that the destination IP is trusted and the
istio sidecar will not attempt to lookup the IP itself.

using resolution:NONE alone would introduce the possibility to
exfiltrate data by spoofing SNI, so we scope the addresses to only
thoses within the VPC.