### PR TITLE
Specify the correct port number for RDS Aurora Postgres

### DIFF
--- a/clusters/sandbox-values.yaml
+++ b/clusters/sandbox-values.yaml
@@ -21,8 +21,8 @@ egressSafelist:
     hosts: ["*.eu-west-2.rds.amazonaws.com"]
     addresses: ["10.0.0.0/8"]
     ports:
-    - name: postgres
-      number: 5432
+    - name: aurora
+      number: 3306
       protocol: TLS
     location: MESH_EXTERNAL
     resolution: NONE


### PR DESCRIPTION
- The Postgres default port of 5432 is not correct. Aurora exposes 3306
  for Postgres, which is confusingly also the MySQL port.