### PR TITLE
Fix Istio resolving the wildcard s3 domain

### DIFF
--- a/clusters/sandbox-values.yaml
+++ b/clusters/sandbox-values.yaml
@@ -28,9 +28,7 @@ egressSafelist:
     resolution: NONE
 - name: s3
   service:
-    hosts:
-      - "s3.eu-west-2.amazonaws.com"
-      - "*.s3-control.eu-west-2.amazonaws.com"
+    hosts: ["s3.eu-west-2.amazonaws.com"]
     ports:
     - name: https
       number: 443


### PR DESCRIPTION
- This gave an error:
  ```
  Error from server: error when creating
  "manifests/gsp-cluster/templates/02-gsp-system/egress-safelist.yaml":
  admission webhook "pilot.validation.istio.io" denied the request:
  configuration is invalid: hosts must be FQDN if no endpoints are
  provided for resolution mode DNS
  ```