### PR TITLE
Scale down original worker ASG to 0

### DIFF
--- a/clusters/sandbox.yaml
+++ b/clusters/sandbox.yaml
@@ -30,7 +30,7 @@ users-repository: "gds-trusted-developers"
 users-path: "users"
 disable-destroy: false
 worker-instance-type: m5d.large
-worker-count: 6
+worker-count: 0
 extra-workers-per-az-count: 1
 ci-worker-instance-type: t3.large
 ci-worker-count: 3


### PR DESCRIPTION
This scales down our original worker ASG to 0 nodes.

The `extra-workers-per-az-count` value guarantees that we will still
have at least 1 worker per AZ.

alphagov/gsp#600 added the cluster autoscaler, which I'm hoping will
scale up the per-AZ nodegroups to compensate for the loss of these
nodes.  Furthermore, it will scale the cluster to the right size for
the number & size of pods it's running.