### PR TITLE
Allow sandbox to scale up to 4 worker nodes per AZ

### DIFF
--- a/clusters/sandbox.yaml
+++ b/clusters/sandbox.yaml
@@ -32,7 +32,7 @@ disable-destroy: false
 worker-instance-type: m5d.large
 extra-workers-per-az-count: 1
 minimum-workers-per-az-count: 1
-maximum-workers-per-az-count: 3
+maximum-workers-per-az-count: 4
 ci-worker-instance-type: t3.large
 ci-worker-count: 3
 github-approval-count: 0


### PR DESCRIPTION
We're hitting the limit now so stuff is not getting scheduled and the sandbox
is broken.