### PR TITLE
[DO NOT MERGE] Change instance type.

### DIFF
--- a/clusters/sandbox.yaml
+++ b/clusters/sandbox.yaml
@@ -29,7 +29,7 @@ users-organization: "alphagov"
 users-repository: "gds-trusted-developers"
 users-path: "users"
 disable-destroy: false
-worker-instance-type: m5d.large
+worker-instance-type: m5.large
 extra-workers-per-az-count: 1
 minimum-workers-per-az-count: 1
 maximum-workers-per-az-count: 4


### PR DESCRIPTION
The 'd' types aren't useful in EKS land as the local disk gets replaced by
the EBS volume anyway.

Before merge:

- [ ] Terraform upgrade rolled out to all clusters
- [ ] `Deploy` job paused in all pipelines