### PR TITLE
remove namespace sandbox-phil-playground

### DIFF
--- a/clusters/sandbox-values.yaml
+++ b/clusters/sandbox-values.yaml
@@ -75,9 +75,6 @@ namespaces:
     enabled: true
 - name: spike-dcs-mtls
 - name: sandbox-gsp-service-operator-test
-- name: sandbox-phil-playground
-  ingress:
-    enabled: true
 
 extraPermissionsSRE:
   - apiGroups: ["verify.gov.uk"]


### PR DESCRIPTION
This isn't needed and it's causing alert noise

This will require manual cleanup afterwards