### PR TITLE
Enable CLS integration in sandbox

### DIFF
--- a/clusters/sandbox.yaml
+++ b/clusters/sandbox.yaml
@@ -39,3 +39,4 @@ github-approval-count: 0
 config-approval-count: 0
 github-release-tag-prefix: "gsp-"
 enable-nlb: 1
+cls-destination-enabled: 1


### PR DESCRIPTION
This won't have any effect until https://github.com/alphagov/gsp/pull/798 is done. `cls-destination-arn` will be injected via a Big Concourse secret.