### PR TITLE
Revert "Swap from m5d.large worker nodes to m5.large"

### DIFF
--- a/clusters/sandbox.yaml
+++ b/clusters/sandbox.yaml
@@ -29,7 +29,7 @@ users-organization: "alphagov"
 users-repository: "gds-trusted-developers"
 users-path: "users"
 disable-destroy: false
-worker-instance-type: m5.large
+worker-instance-type: m5d.large
 extra-workers-per-az-count: 1
 minimum-workers-per-az-count: 1
 maximum-workers-per-az-count: 4


### PR DESCRIPTION
This reverts commit 5739ca7065f4cb4c207d4e8a5462f3fecf3e9e83.

Let's re-run this with https://github.com/alphagov/gsp/pull/799 and https://github.com/alphagov/gsp/pull/803