### PR TITLE
Revert "Enable CLS integration in sandbox"

### DIFF
--- a/clusters/sandbox.yaml
+++ b/clusters/sandbox.yaml
@@ -39,4 +39,3 @@ github-approval-count: 0
 config-approval-count: 0
 github-release-tag-prefix: "gsp-"
 enable-nlb: 1
-cls-destination-enabled: 1


### PR DESCRIPTION
This reverts commit f831fbef0de6c6bfd4d27b77d90973d01494b2bc.

We haven't been whitelisted for access and won't be today.