### PR TITLE
Revert "Re-enable CLS integration in sandbox"

### DIFF
--- a/clusters/sandbox.yaml
+++ b/clusters/sandbox.yaml
@@ -39,4 +39,3 @@ github-approval-count: 0
 config-approval-count: 0
 github-release-tag-prefix: "gsp-"
 enable-nlb: 1
-cls-destination-enabled: 1


### PR DESCRIPTION
This reverts commit fac5be29d239606550587b43d8c3359dfd4848b5.

Access was revoked as things stopped working when we started sending logs.