### PR TITLE
Add multi-country proxy node egress urls

### DIFF
--- a/clusters/sandbox-values.yaml
+++ b/clusters/sandbox-values.yaml
@@ -23,6 +23,12 @@ egressSafelist:
       - test-connector.london.sandbox.govsvc.uk
       # multi-country stub-connector
       - stub-connector.eidas.test.london.sandbox.govsvc.uk
+      - stgmteidasnode.gov.mt/EidasNode/ConnectorMetadata
+      - eidastest.eesti.ee/EidasNode/ConnectorMetadata
+      - testnode.island.is/eidas-node/ConnectorMetadata
+      - eidas.difi.no/EidasNode/ConnectorMetadata
+      - mteidasnode.gov.mt/EidasNode/ConnectorMetadata
+      - https://acc-eidas.minez.nl/EidasNodeC/ConnectorMetadata
     ports:
     - name: https
       number: 443

--- a/clusters/sandbox-values.yaml
+++ b/clusters/sandbox-values.yaml
@@ -28,7 +28,7 @@ egressSafelist:
       - testnode.island.is/eidas-node/ConnectorMetadata
       - eidas.difi.no/EidasNode/ConnectorMetadata
       - mteidasnode.gov.mt/EidasNode/ConnectorMetadata
-      - https://acc-eidas.minez.nl/EidasNodeC/ConnectorMetadata
+      - acc-eidas.minez.nl/EidasNodeC/ConnectorMetadata
     ports:
     - name: https
       number: 443
@@ -100,4 +100,3 @@ extraPermissionsDev:
     - get
     - list
     - watch
-


### PR DESCRIPTION
Add egress URLs for the multi-country proxy node so that metadata can be retrieved.