### PR TITLE
use t3.xlarge for sandbox workers

### DIFF
--- a/clusters/sandbox.yaml
+++ b/clusters/sandbox.yaml
@@ -24,7 +24,7 @@ users-organization: "alphagov"
 users-repository: "gds-trusted-developers"
 users-path: "users"
 disable-destroy: false
-worker-instance-type: m5.large
+worker-instance-type: t3.xlarge
 extra-workers-per-az-count: 1
 minimum-workers-per-az-count: 1
 maximum-workers-per-az-count: 4


### PR DESCRIPTION
production clusters use xlarge worker nodes, this changes sandbox to
also use xlarge nodes, keeping the sandbox workers more inline with
production clusters when it comes to memory limits.

since CPU ultilization is below 50% accross all the nodes in sandbox, it
makes sense for these to be t3 instances to save money.