### PR TITLE
remove worker-instance-type variable

### DIFF
--- a/clusters/sandbox.yaml
+++ b/clusters/sandbox.yaml
@@ -24,7 +24,6 @@ users-organization: "alphagov"
 users-repository: "gds-trusted-developers"
 users-path: "users"
 disable-destroy: false
-worker-instance-type: t3.xlarge
 extra-workers-per-az-count: 1
 minimum-workers-per-az-count: 1
 maximum-workers-per-az-count: 4


### PR DESCRIPTION
This doesn't do anything any more since the spot instances work