### PR TITLE
Run 100% spot instances

### DIFF
--- a/clusters/sandbox.yaml
+++ b/clusters/sandbox.yaml
@@ -27,6 +27,7 @@ disable-destroy: false
 extra-workers-per-az-count: 1
 minimum-workers-per-az-count: 1
 maximum-workers-per-az-count: 4
+worker-on-demand-base-capacity: 0
 worker-on-demand-percentage-above-base: 0
 ci-worker-instance-type: t3.large
 ci-worker-count: 3


### PR DESCRIPTION
Use the new worker-on-demand-base-capacity config value to run 0 base
capacity on-demand instances and 0% on-demand instances above that.